### PR TITLE
Add config option to include the class from which sysout was called

### DIFF
--- a/src/main/java/net/draycia/sysoutcatcher/SysoutCatcher.java
+++ b/src/main/java/net/draycia/sysoutcatcher/SysoutCatcher.java
@@ -15,7 +15,14 @@ public final class SysoutCatcher extends JavaPlugin {
 
                 try {
                     Class<?> caller = stackWalker.getCallerClass();
-                    JavaPlugin.getProvidingPlugin(caller).getLogger().info(line);
+
+                    StringBuilder messageBuilder = new StringBuilder();
+                    if (getConfig().getBoolean("IncludeSourceClass", false)) {
+                        messageBuilder.append('(').append(caller.getName()).append(") ");
+                    }
+                    messageBuilder.append(line);
+
+                    JavaPlugin.getProvidingPlugin(caller).getLogger().info(messageBuilder.toString());
                 } catch (IllegalArgumentException e) {
                     StackTraceElement element = new Exception().getStackTrace()[2];
                     super.printf("(%s:%d) %s\n", element.getClassName(), element.getLineNumber(), line);
@@ -25,6 +32,11 @@ public final class SysoutCatcher extends JavaPlugin {
         };
 
         System.setOut(myStream);
+    }
+
+    @Override
+    public void onEnable() {
+        this.saveDefaultConfig();
     }
 
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+IncludeSourceClass: false


### PR DESCRIPTION
A small adjustment to add a configuration option detailing the exact class from which the `System.out.println()` call is being made. This is useful if as a developer you are trying to narrow down where the method is being invoked so it may be removed and/or modified.

![Console log](https://i.imgur.com/nJJRG7w.png)

_Defaulting to false ensures behaviour remains the same when updating_